### PR TITLE
Docstrings and changed prompt template param

### DIFF
--- a/examples/base_usage.py
+++ b/examples/base_usage.py
@@ -35,14 +35,17 @@ mind = client.minds.create(name='mind_name', datasources=[postgres_config] )
 
 # or separately
 datasource = client.datasources.create(postgres_config)
-mind2 = client.minds.create(name='mind_name', datasources=[datasource] )
+mind = client.minds.create(name='mind_name', datasources=[datasource] )
+
+# with prompt template
+mind = client.minds.create(name='mind_name', prompt_template='You are codding assistant')
 
 # or add to existed mind
-mind3 = client.minds.create(name='mind_name')
+mind = client.minds.create(name='mind_name')
 # by config
-mind2.add_datasource(postgres_config)
+mind.add_datasource(postgres_config)
 # or by datasource
-mind2.add_datasource(datasource)
+mind.add_datasource(datasource)
 
 
 # --- managing minds ---

--- a/minds/datasources/datasources.py
+++ b/minds/datasources/datasources.py
@@ -21,6 +21,18 @@ class Datasources:
         self.api = client.api
 
     def create(self, ds_config: DatabaseConfig, replace=False):
+        """
+        Create new datasource and return it
+
+        :param ds_config: datasource configuration, properties:
+           - name: str, name of datatasource
+           - engine: str, type of database handler, for example 'postgres', 'mysql', ...
+           - description: str, description of the database. Used by mind to know what data can be got from it.
+           - connection_data: dict, optional, credentials to connect to database
+           - tables: list of str, optional, list of allowed tables
+        :return: datasource object
+        """
+
         name = ds_config.name
 
         if replace:
@@ -34,6 +46,12 @@ class Datasources:
         return self.get(name)
 
     def list(self) -> List[Datasource]:
+        """
+        Returns list of datasources
+
+        :return: iterable datasources
+        """
+
         data = self.api.get('/datasources').json()
         ds_list = []
         for item in data:
@@ -44,6 +62,13 @@ class Datasources:
         return ds_list
 
     def get(self, name: str) -> Datasource:
+        """
+        Get datasource by name
+
+        :param name: name of datasource
+        :return: datasource object
+        """
+
         data = self.api.get(f'/datasources/{name}').json()
 
         # TODO skip not sql skills
@@ -52,4 +77,10 @@ class Datasources:
         return Datasource(**data)
 
     def drop(self, name: str):
+        """
+        Drop datasource by name
+
+        :param name: name of datasource
+        """
+
         self.api.delete(f'/datasources/{name}')

--- a/minds/minds.py
+++ b/minds/minds.py
@@ -126,11 +126,11 @@ class Mind:
             stream=stream
         )
         if stream:
-            return self.stream_response(response)
+            return self._stream_response(response)
         else:
             return response.choices[0].message.content
 
-    def stream_response(self, response):
+    def _stream_response(self, response):
         for chunk in response:
             yield chunk.choices[0].delta
 
@@ -143,6 +143,12 @@ class Minds:
         self.project = 'mindsdb'
 
     def list(self) -> List[Mind]:
+        """
+        Returns list of minds
+
+        :return: iterable
+        """
+
         data = self.api.get(f'/projects/{self.project}/minds').json()
         minds_list = []
         for item in data:
@@ -150,6 +156,13 @@ class Minds:
         return minds_list
 
     def get(self, name: str) -> Mind:
+        """
+        Get mind by name
+
+        :param name: name of the mind
+        :return: a mind object
+        """
+
         item = self.api.get(f'/projects/{self.project}/minds/{name}').json()
         return Mind(self.client, **item)
 
@@ -211,4 +224,10 @@ class Minds:
         return mind
 
     def drop(self, name: str):
+       """
+       Drop mind by name
+
+       :param name: name of the mind
+       """
+
        self.api.delete(f'/projects/{self.project}/minds/{name}')

--- a/minds/minds.py
+++ b/minds/minds.py
@@ -46,6 +46,23 @@ class Mind:
         datasources=None,
         parameters=None,
     ):
+        """
+        Update mind
+
+        If parameter is set it will be applied to mind
+
+        Datasource can be passed as
+         - name, str
+         - Datasource object (minds.datasources.Database)
+         - datasource config (minds.datasources.DatabaseConfig), in this case datasource will be created
+
+        :param name: new name of the mind, optional
+        :param model_name: new llm model name, optional
+        :param provider: new llm provider, optional
+        :param prompt_template: new prompt template, optional
+        :param datasources: alter list of datasources used by mind, optional
+        :param parameters, dict: alter other parameters of the mind, optional
+        """
         data = {}
 
         if datasources is not None:
@@ -77,6 +94,15 @@ class Mind:
             self.name = name
 
     def add_datasource(self, datasource: Datasource):
+        """
+        Add datasource to mind
+        Datasource can be passed as
+         - name, str
+         - Datasource object (minds.datasources.Database)
+         - datasource config (minds.datasources.DatabaseConfig), in this case datasource will be created
+
+        :param datasource: input datasource
+        """
 
         ds_name = self.client.minds._check_datasource(datasource)
 
@@ -91,6 +117,15 @@ class Mind:
         self.datasources = updated.datasources
 
     def del_datasource(self, datasource: Union[Datasource, str]):
+        """
+        Delete datasource from mind
+
+        Datasource can be passed as
+         - name, str
+         - Datasource object (minds.datasources.Database)
+
+        :param datasource: datasource to delete
+        """
         if isinstance(datasource, Datasource):
             datasource = datasource.name
         elif not isinstance(datasource, str):
@@ -199,6 +234,23 @@ class Minds:
         parameters=None,
         replace=False,
     ) -> Mind:
+        """
+        Create a new mind and return it
+
+        Datasource can be passed as
+         - name, str
+         - Datasource object (minds.datasources.Database)
+         - datasource config (minds.datasources.DatabaseConfig), in this case datasource will be created
+
+        :param name: name of the mind
+        :param model_name: llm model name, optional
+        :param provider: llm provider, optional
+        :param prompt_template: instructions to llm, optional
+        :param datasources: list of datasources used by mind, optional
+        :param parameters, dict: other parameters of the mind, optional
+        :param replace: if true - to remove existing mind, default is false
+        :return: created mind
+        """
 
         if replace:
             try:

--- a/minds/minds.py
+++ b/minds/minds.py
@@ -28,6 +28,9 @@ class Mind:
         self.name = name
         self.model_name = model_name
         self.provider = provider
+        if parameters is None:
+            parameters = {}
+        self.prompt_template = parameters.pop('prompt_template', None)
         self.parameters = parameters
         self.created_at = created_at
         self.updated_at = updated_at
@@ -39,8 +42,9 @@ class Mind:
         name: str = None,
         model_name: str = None,
         provider=None,
+        prompt_template=None,
+        datasources=None,
         parameters=None,
-        datasources=None
     ):
         data = {}
 
@@ -57,8 +61,13 @@ class Mind:
             data['model_name'] = model_name
         if provider is not None:
             data['provider'] = provider
-        if parameters is not None:
-            data['parameters'] = parameters
+        if parameters is None:
+            parameters = {}
+
+        data['parameters'] = parameters
+
+        if prompt_template is not None:
+            data['parameters']['prompt_template'] = prompt_template
 
         self.api.patch(
             f'/projects/{self.project}/minds/{self.name}',
@@ -185,8 +194,9 @@ class Minds:
         self, name,
         model_name=None,
         provider=None,
-        parameters=None,
+        prompt_template=None,
         datasources=None,
+        parameters=None,
         replace=False,
     ) -> Mind:
 
@@ -206,6 +216,9 @@ class Minds:
 
         if parameters is None:
             parameters = {}
+
+        if prompt_template is not None:
+            parameters['prompt_template'] = prompt_template
         if 'prompt_template' not in parameters:
             parameters['prompt_template'] = DEFAULT_PROMPT_TEMPLATE
 

--- a/tests/integration/test_base_flow.py
+++ b/tests/integration/test_base_flow.py
@@ -88,15 +88,13 @@ def test_minds():
         mind_name,
         replace=True,
         datasources=[ds.name, ds2_cfg],
-        parameters={
-            'prompt_template': prompt1
-        }
+        prompt_template=prompt1
     )
 
     # get
     mind = client.minds.get(mind_name)
     assert len(mind.datasources) == 2
-    assert mind.parameters['prompt_template'] == prompt1
+    assert mind.prompt_template == prompt1
 
     # list
     mind_list = client.minds.list()
@@ -106,9 +104,7 @@ def test_minds():
     mind.update(
         name=mind_name2,
         datasources=[ds.name],
-        parameters={
-            'prompt_template': prompt2
-        }
+        prompt_template=prompt2
     )
     with pytest.raises(ObjectNotFound):
         # this name not exists
@@ -116,7 +112,7 @@ def test_minds():
 
     mind = client.minds.get(mind_name2)
     assert len(mind.datasources) == 1
-    assert mind.parameters['prompt_template'] == prompt2
+    assert mind.prompt_template == prompt2
 
     # add datasource
     mind.add_datasource(ds2_cfg)

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -121,14 +121,14 @@ class TestMinds:
         client = get_client()
 
         mind_name = 'test_mind'
-        parameters = {'prompt_template': 'always agree'}
+        prompt_template = 'always agree'
         datasources = ['my_ds']
         provider = 'openai'
 
         response_mock(mock_get, self.mind_json)
         create_params = {
             'name': mind_name,
-            'parameters': parameters,
+            'prompt_template': prompt_template,
             'datasources': datasources
         }
         mind = client.minds.create(**create_params)
@@ -137,8 +137,9 @@ class TestMinds:
             args, kwargs = mock_post.call_args
             assert args[0].endswith('/api/projects/mindsdb/minds')
             request = kwargs['json']
-            for k, v in create_params.items():
-                assert request[k] == v
+            for key in ('name', 'datasources', 'provider', 'model_name'),:
+                assert request.get(key) == create_params.get(key)
+            assert create_params.get('prompt_template') == request.get('parameters', {}).get('prompt_template')
 
             self.compare_mind(mind, self.mind_json)
 
@@ -147,7 +148,7 @@ class TestMinds:
         # with replace
         create_params = {
             'name': mind_name,
-            'parameters': parameters,
+            'prompt_template': prompt_template,
             'provider': provider,
         }
         mind = client.minds.create(replace=True, **create_params)


### PR DESCRIPTION
Added docsting for methods exposed in API
- datasourses
- minds

Changed the way to pass prompt template for create or update mind
Used to be:
```python
mind = client.minds.create(
    'my_mind',
    parameters={
          'prompt_template': 'do the best'
    }
)
```

Will be:
```python
mind = client.minds.create(
    'my_mind',
    prompt_template='do the best'
)
```