### PR TITLE
Ruby SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,5 @@ client.datasources.drop('my_datasource')
 ```
 >Note: The SDK currently does not support automatically removing a data source if it is no longer connected to any mind.
 
+### Other SDKs
+#### Ruby SDK: [https://github.com/tungnt1203/minds_ruby_sdk](https://github.com/tungnt1203/minds_ruby_sdk)


### PR DESCRIPTION
 Ruby SDK for the Minds API, providing similar functionality to the existing Python SDK:
> This repo: https://github.com/tungnt1203/minds_ruby_sdk
> issue [#22](https://github.com/mindsdb/minds_python_sdk/issues/22)
- Client class for API authentication and requests
- Classes for managing Datasources and Minds
- CRUD operations for resources
- Mind completion support
- Error handling