### PR TITLE
Upsert minds/datasources

### DIFF
--- a/minds/datasources/datasources.py
+++ b/minds/datasources/datasources.py
@@ -16,11 +16,12 @@ class DatabaseConfig(BaseModel):
 class Datasource(DatabaseConfig):
     ...
 
+
 class Datasources:
     def __init__(self, client):
         self.api = client.api
 
-    def create(self, ds_config: DatabaseConfig, replace=False):
+    def create(self, ds_config: DatabaseConfig, replace=False, update=False):
         """
         Create new datasource and return it
 
@@ -30,6 +31,8 @@ class Datasources:
            - description: str, description of the database. Used by mind to know what data can be got from it.
            - connection_data: dict, optional, credentials to connect to database
            - tables: list of str, optional, list of allowed tables
+        :param replace: if true - to remove existing datasource, default is false
+        :param update: if true - to update datasourse if exists, default is false
         :return: datasource object
         """
 
@@ -42,7 +45,10 @@ class Datasources:
             except exc.ObjectNotFound:
                 ...
 
-        self.api.post('/datasources', data=ds_config.model_dump())
+        if update:
+            self.api.put('/datasources', data=ds_config.model_dump())
+        else:
+            self.api.post('/datasources', data=ds_config.model_dump())
         return self.get(name)
 
     def list(self) -> List[Datasource]:

--- a/minds/datasources/datasources.py
+++ b/minds/datasources/datasources.py
@@ -21,7 +21,7 @@ class Datasources:
     def __init__(self, client):
         self.api = client.api
 
-    def create(self, ds_config: DatabaseConfig, replace=False, update=False):
+    def create(self, ds_config: DatabaseConfig, update=False):
         """
         Create new datasource and return it
 
@@ -31,19 +31,11 @@ class Datasources:
            - description: str, description of the database. Used by mind to know what data can be got from it.
            - connection_data: dict, optional, credentials to connect to database
            - tables: list of str, optional, list of allowed tables
-        :param replace: if true - to remove existing datasource, default is false
         :param update: if true - to update datasourse if exists, default is false
         :return: datasource object
         """
 
         name = ds_config.name
-
-        if replace:
-            try:
-                self.get(name)
-                self.drop(name, force=True)
-            except exc.ObjectNotFound:
-                ...
 
         if update:
             self.api.put('/datasources', data=ds_config.model_dump())

--- a/minds/minds.py
+++ b/minds/minds.py
@@ -243,6 +243,7 @@ class Minds:
         datasources=None,
         parameters=None,
         replace=False,
+        update=False,
     ) -> Mind:
         """
         Create a new mind and return it
@@ -259,6 +260,7 @@ class Minds:
         :param datasources: list of datasources used by mind, optional
         :param parameters, dict: other parameters of the mind, optional
         :param replace: if true - to remove existing mind, default is false
+        :param update: if true - to update mind if exists, default is false
         :return: created mind
         """
 
@@ -284,7 +286,12 @@ class Minds:
         if 'prompt_template' not in parameters:
             parameters['prompt_template'] = DEFAULT_PROMPT_TEMPLATE
 
-        self.api.post(
+        if update:
+            method = self.api.put
+        else:
+            method = self.api.post
+
+        method(
             f'/projects/{self.project}/minds',
             data={
                 'name': name,

--- a/minds/rest_api.py
+++ b/minds/rest_api.py
@@ -53,6 +53,16 @@ class RestAPI:
         _raise_for_status(resp)
         return resp
 
+    def put(self, url, data):
+        resp = requests.put(
+            self.base_url + url,
+            headers=self._headers(),
+            json=data,
+        )
+
+        _raise_for_status(resp)
+        return resp
+
     def patch(self, url, data):
         resp = requests.patch(
             self.base_url + url,

--- a/tests/integration/test_base_flow.py
+++ b/tests/integration/test_base_flow.py
@@ -93,6 +93,12 @@ def test_minds():
         datasources=[ds.name, ds2_cfg],
         prompt_template=prompt1
     )
+    mind = client.minds.create(
+        mind_name,
+        update=True,
+        datasources=[ds.name, ds2_cfg],
+        prompt_template=prompt1
+    )
 
     # get
     mind = client.minds.get(mind_name)

--- a/tests/integration/test_base_flow.py
+++ b/tests/integration/test_base_flow.py
@@ -38,8 +38,6 @@ def test_datasources():
     # create
     ds = client.datasources.create(example_ds)
     assert ds.name == example_ds.name
-    ds = client.datasources.create(example_ds, replace=True)
-    assert ds.name == example_ds.name
     ds = client.datasources.create(example_ds, update=True)
     assert ds.name == example_ds.name
 

--- a/tests/integration/test_base_flow.py
+++ b/tests/integration/test_base_flow.py
@@ -37,7 +37,10 @@ def test_datasources():
 
     # create
     ds = client.datasources.create(example_ds)
+    assert ds.name == example_ds.name
     ds = client.datasources.create(example_ds, replace=True)
+    assert ds.name == example_ds.name
+    ds = client.datasources.create(example_ds, update=True)
     assert ds.name == example_ds.name
 
     # get

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -54,13 +54,6 @@ class TestDatasources:
 
         check_ds_created(ds, mock_post)
 
-        # with replace
-        ds = client.datasources.create(example_ds, replace=True)
-        args, _ = mock_del.call_args
-        assert args[0].endswith(f'/api/datasources/{example_ds.name}')
-
-        check_ds_created(ds, mock_post)
-
         # with update
         ds = client.datasources.create(example_ds, update=True)
         check_ds_created(ds, mock_put)

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -36,9 +36,10 @@ class TestDatasources:
         assert ds1.tables == ds2.tables
 
     @patch('requests.get')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.delete')
-    def test_create_datasources(self, mock_del, mock_post, mock_get):
+    def test_create_datasources(self, mock_del, mock_post, mock_put, mock_get):
         client = get_client()
         response_mock(mock_get, example_ds.model_dump())
 
@@ -59,6 +60,10 @@ class TestDatasources:
         assert args[0].endswith(f'/api/datasources/{example_ds.name}')
 
         check_ds_created(ds, mock_post)
+
+        # with update
+        ds = client.datasources.create(example_ds, update=True)
+        check_ds_created(ds, mock_put)
 
     @patch('requests.get')
     def test_get_datasource(self, mock_get):

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -120,9 +120,10 @@ class TestMinds:
         assert mind.parameters == mind_json['parameters']
 
     @patch('requests.get')
+    @patch('requests.put')
     @patch('requests.post')
     @patch('requests.delete')
-    def test_create(self, mock_del, mock_post, mock_get):
+    def test_create(self, mock_del, mock_post, mock_put, mock_get):
         client = get_client()
 
         mind_name = 'test_mind'
@@ -150,7 +151,7 @@ class TestMinds:
 
         check_mind_created(mind, mock_post, create_params)
 
-        # with replace
+        # -- with replace --
         create_params = {
             'name': mind_name,
             'prompt_template': prompt_template,
@@ -163,6 +164,14 @@ class TestMinds:
         assert args[0].endswith(f'/api/projects/mindsdb/minds/{mind_name}')
 
         check_mind_created(mind, mock_post, create_params)
+
+        # -- with update --
+        mock_del.reset_mock()
+        mind = client.minds.create(update=True, **create_params)
+        # is not deleted
+        assert not mock_del.called
+
+        check_mind_created(mind, mock_put, create_params)
 
     @patch('requests.get')
     @patch('requests.patch')


### PR DESCRIPTION
Added update parameter for minds.create and datasources.create. 
If it is set: mind or datasource will be updated if it is exist

```python

datasource = client.datasources.create(example_ds, update=True)

mind = client.minds.create(mind_name, update=True)

```

Dependent on https://github.com/mindsdb/mindsdb_gateway/pull/956