### PR TITLE
Delete datasource cascade

### DIFF
--- a/minds/datasources/datasources.py
+++ b/minds/datasources/datasources.py
@@ -38,7 +38,7 @@ class Datasources:
         if replace:
             try:
                 self.get(name)
-                self.drop(name)
+                self.drop(name, force=True)
             except exc.ObjectNotFound:
                 ...
 
@@ -76,15 +76,15 @@ class Datasources:
             raise exc.ObjectNotSupported(f'Wrong type of datasource: {name}')
         return Datasource(**data)
 
-    def drop(self, name: str, cascade=False):
+    def drop(self, name: str, force=False):
         """
         Drop datasource by name
 
         :param name: name of datasource
-        :param cascade: if True - remove from all minds, default: False
+        :param force: if True - remove from all minds, default: False
         """
         data = None
-        if cascade:
+        if force:
             data = {'cascade': True}
 
         self.api.delete(f'/datasources/{name}', data=data)

--- a/minds/datasources/datasources.py
+++ b/minds/datasources/datasources.py
@@ -76,11 +76,15 @@ class Datasources:
             raise exc.ObjectNotSupported(f'Wrong type of datasource: {name}')
         return Datasource(**data)
 
-    def drop(self, name: str):
+    def drop(self, name: str, cascade=False):
         """
         Drop datasource by name
 
         :param name: name of datasource
+        :param cascade: if True - remove from all minds, default: False
         """
+        data = None
+        if cascade:
+            data = {'cascade': True}
 
-        self.api.delete(f'/datasources/{name}')
+        self.api.delete(f'/datasources/{name}', data=data)

--- a/minds/rest_api.py
+++ b/minds/rest_api.py
@@ -37,8 +37,12 @@ class RestAPI:
         _raise_for_status(resp)
         return resp
 
-    def delete(self, url):
-        resp = requests.delete(self.base_url + url, headers=self._headers())
+    def delete(self, url, data=None):
+        resp = requests.delete(
+            self.base_url + url,
+            headers=self._headers(),
+            json=data
+        )
 
         _raise_for_status(resp)
         return resp

--- a/tests/integration/test_base_flow.py
+++ b/tests/integration/test_base_flow.py
@@ -31,7 +31,7 @@ def test_datasources():
 
     # remove previous object
     try:
-        client.datasources.drop(example_ds.name, cascade=True)
+        client.datasources.drop(example_ds.name, force=True)
     except ObjectNotFound:
         ...
 

--- a/tests/integration/test_base_flow.py
+++ b/tests/integration/test_base_flow.py
@@ -31,7 +31,7 @@ def test_datasources():
 
     # remove previous object
     try:
-        client.datasources.drop(example_ds.name)
+        client.datasources.drop(example_ds.name, cascade=True)
     except ObjectNotFound:
         ...
 


### PR DESCRIPTION
`force` parameter to drop deleted datasource from all minds

```python
client.datasources.drop(example_ds.name, force=True)
```

dependent on https://github.com/mindsdb/mindsdb_gateway/pull/953