### PR TITLE
Limit tables of datasourse in context of the mind

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ mind3.add_datasource(postgres_config)  # Using the config
 mind3.add_datasource(datasource)       # Using the data source object
 ```
 
+Create mind with tables restriction for datasource:
+```python
+from minds.datasources.datasources import DatabaseTables
+datasource = DatabaseTables(
+    name='my_db',
+    tables=['table1', 'table1'],
+)
+mind4 = client.minds.create(name='mind_name', datasources=[datasource])
+```
+
+
 ### Managing Minds
 
 You can create a mind or replace an existing one with the same name.

--- a/examples/base_usage.py
+++ b/examples/base_usage.py
@@ -40,6 +40,11 @@ mind = client.minds.create(name='mind_name', datasources=[datasource] )
 # with prompt template
 mind = client.minds.create(name='mind_name', prompt_template='You are codding assistant')
 
+# restrict tables for datasource in context of the mind:
+from minds.datasources.datasources import DatabaseTables
+datasource = DatabaseTables(name='my_datasource', tables=['table1', 'table1'])
+mind = client.minds.create(name='mind_name', datasources=[datasource])
+
 # or add to existed mind
 mind = client.minds.create(name='mind_name')
 # by config

--- a/minds/datasources/datasources.py
+++ b/minds/datasources/datasources.py
@@ -4,16 +4,35 @@ from pydantic import BaseModel, Field
 import minds.utils as utils
 import minds.exceptions as exc
 
-class DatabaseConfig(BaseModel):
 
+class DatabaseConfigBase(BaseModel):
+    """
+    Base class
+    """
     name: str
-    engine: str
-    description: str
-    connection_data: Union[dict, None] = {}
     tables: Union[List[str], None] = []
 
 
+class DatabaseTables(DatabaseConfigBase):
+    """
+    Used when only database and tables are required to be defined. For example in minds.create
+    """
+    ...
+
+
+class DatabaseConfig(DatabaseConfigBase):
+    """
+    Used to define datasource before creating it.
+    """
+    engine: str
+    description: str
+    connection_data: Union[dict, None] = {}
+
+
 class Datasource(DatabaseConfig):
+    """
+    Existed datasource. It is returned by this SDK when datasource is queried from server
+    """
     ...
 
 


### PR DESCRIPTION
Implements API added in https://github.com/mindsdb/mindsdb_gateway/pull/974

It allows to limit tables of datasource used by mind only in context of the mind. It is done without modifying datasource.

Usage:
```python
from minds.datasources.datasources import DatabaseTables
datasource = DatabaseTables(
    name='my_db',                 # use existed datasource name
    tables=['table1', 'table1'],  # add limitation for used tables
)
mind4 = client.minds.create(name='mind_name', datasources=[datasource])
```


Fixes: https://linear.app/mindsdb/issue/BE-610/create-mind-use-list-of-tables-for-datasource